### PR TITLE
Ensure that notebooks execute top to bottom without errors.

### DIFF
--- a/.github/workflows/execute_notebooks.yml
+++ b/.github/workflows/execute_notebooks.yml
@@ -1,0 +1,34 @@
+name: Execute notebooks top to bottom to ensure no errors.
+on:
+  push:
+  pull-request:
+  schedule:
+      - cron: '00 4 * * *'  # daily at 4AM 
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout files in repo.
+      uses: actions/checkout@main
+
+    - name: Set up Python 3.x.
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dev requirements.
+      shell: bash -l {0}
+      run: |
+        set -vxeuo pipefail
+        python -m pip install -r binder/requirements-dev
+        python -m pip install list
+
+    - name: Execute notebooks with papermill.
+      shell: bash -l {0}
+      run: |
+        set -vxeuo pipefail
+        # The notebook output will be directed to /dev/null but if there is any
+        # error execution will stop and the error will be shown in stderr (and
+        # hence in the logs).
+        jupyter-repo2docker . pip install papermill && papermill *.ipynb - > /dev/null


### PR DESCRIPTION
I did some reading about the best way to do this.

Our previous approach used `nbsphinx`, coupling the execution to the generation of sphinx documentation. That made errors much harder to debug. I am still interested in generating a static HTML copy of the documentation, likely involving sphinx, but I think we should do it in a separate, second step after we have verified that the notebooks runs.

The most minimal approach available seems to be the new [nbclient](https://github.com/jupyter/nbclient). But it has no CLI interface, only a Python one. Modern papermill (2.x+) is basically a CLI around nbclient, with optional templating. In this PR, we use papermill to execute the notebooks.

The key line is:

```
jupyter-repo2docker . pip install papermill && papermill *.ipynb - > /dev/null
```

This starts up the container and overrides its `ENTRYPOINT` to install and run `papermill` on all the notebooks instead of launching a Jupyter server. 

Some example output in the event of an error:

```
papermill.exceptions.PapermillExecutionError: 
---------------------------------------------------------------------------
Exception encountered at "In [1]":
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-1-9e1622b385b6> in <module>
----> 1 1/0

ZeroDivisionError: division by zero
```

Known limitation: This will only find notebooks located in the root directory. That seems fine for now.